### PR TITLE
Replaces the git protocol with https

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -9,7 +9,7 @@
 #>
 
 # Clone chrissimpkins/codeface
-git clone git://github.com/chrissimpkins/codeface.git
+git clone https://github.com/chrissimpkins/codeface.git
 
 $fontFiles = New-Object 'System.Collections.Generic.List[System.IO.FileInfo]'
 Get-ChildItem $PSScriptRoot/codeface/fonts -Filter "*.ttf" -Recurse | Foreach-Object {$fontFiles.Add($_)}


### PR DESCRIPTION
An error [`fatal: unable to connect to github.com: github.com`] is thrown when I try to execute this script. GitHub has dropped support for the git:// protocol. Everything else works fine.